### PR TITLE
Rename 'has-valid-header' to 'has-valid-ar-header'.

### DIFF
--- a/src/ar.toit
+++ b/src/ar.toit
@@ -42,7 +42,7 @@ DETERMINISTIC-MODE_      ::= 0b110_100_100  // Octal 644.
 /**
 Whether the given $bytes start with an AR header.
 */
-has-valid-header bytes/ByteArray -> bool:
+has-valid-ar-header bytes/ByteArray -> bool:
   return bytes.size >= AR-HEADER_.size and bytes[..AR-HEADER_.size] == AR-HEADER_.to-byte-array
 
 /**

--- a/tests/ar_test.toit
+++ b/tests/ar_test.toit
@@ -46,7 +46,7 @@ write-ar file-mapping/Map --add-with-ar-file/bool=false:
 run-test file-mapping/Map tmp-dir [generate-ar]:
   ba := generate-ar.call tmp-dir file-mapping
 
-  expect (has-valid-header ba)
+  expect (has-valid-ar-header ba)
 
   seen := {}
   count := 0
@@ -146,5 +146,5 @@ main:
   run-tests: |tmp-dir file-mapping| write-ar file-mapping
   run-tests: |tmp-dir file-mapping| write-ar file-mapping --add-with-ar-file
 
-  expect-not (has-valid-header "not an ar file".to-byte-array)
-  expect-not (has-valid-header #[])
+  expect-not (has-valid-ar-header "not an ar file".to-byte-array)
+  expect-not (has-valid-ar-header #[])


### PR DESCRIPTION
The ar package is typically imported with `show *`, and not having the 'ar' in the name is unhelpful.